### PR TITLE
Add MusicWithoutDelay.h to library.properties includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=You can play a song in parallel with your program(assuming, you don't 
 category=Timing
 url=https://github.com/nathanRamaNoodles/MusicWithoutDelay-LIbrary
 architectures=avr
-includes=Tone.h
+includes=MusicWithoutDelay.h,Tone.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify the #include directives which should be automatically added to the sketch after the user selects **Sketch > Include Library > MusicWithoutDelay**. Previously this action would only add the line:
```cpp
#include <Tone.h>
```
to the sketch. Thus, MusicWithoutDelay.h must be one of the values specified in this field.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format