### PR TITLE
Port for 32 bit Teensy boards

### DIFF
--- a/src/MusicWithoutDelay.h
+++ b/src/MusicWithoutDelay.h
@@ -180,6 +180,6 @@ private:
   char autoFlat[5];  //you can only have 5 of the black keys ;)
   char autoSharp[5];
   char songName[15];  //make this smaller to get more SRAM
-  char *mySong;
+  const char *mySong;
 };
 #endif


### PR DESCRIPTION
This lets your library work on Teensy 3.x boards.  The port is pretty simple, using IntervalTimer to replace the timer2 interrupt and analogWrite to replace the direct PWM control.

